### PR TITLE
Modified tutorial for Gromacs 2024.1 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ The second step is a short 1000 step [GROMACS](http://www.gromacs.org) MD simula
     
 The strength of the (soft-core) van der Waals interaction between the protein and the rest of the system is described by a coupling parameter, lambda. Initially, lambda is zero and there are no forces between the protein and the rest of the system. Here lambda increases by 0.001 for 1000 steps, thereby smoothly "turning on" the interactions between the protein and the rest of the system. During this process the position of the protein beads (or atoms) are restrained and as lambda increases the lipid beads (or atoms) move out of the space occupied by the protein.
 
-The `try-alchembed.sh` script takes two arguments (the script is commented also if you'd like to look inside). The name of the protein (taken from the list above) and the forcefield. Hence to run it type
+The `try-alchembed.sh` script takes three arguments (the script is commented also if you'd like to look inside). The name of the protein (taken from the list above) and the forcefield, and the number of OpenMP threads to use (optional, defaults to 1. More is faster, but too many can break the simulation). Hence to run it type, e.g.
 
-    ./try-alchembed.sh nbar cg
+    ./try-alchembed.sh nbar cg 6
 
 and assuming you have [GROMACS](http://www.gromacs.org) in your `$PATH` etc, then it should perform the short energy minimisation and then the embedding simulation. On a single core of at Intel Xeon E5 processor (c. 2014) this took 13 seconds. The larger proteins and the atomistic cases will take longer (nbar at took around 15 min on the same processor).
 

--- a/common-files/alchembed-at.mdp
+++ b/common-files/alchembed-at.mdp
@@ -36,6 +36,6 @@ sc-r-power           = 6
 couple-moltype       = PROTEIN
 couple-lambda0       = none
 couple-lambda1       = vdw
-
+couple-intramol      = yes
 
 

--- a/common-files/alchembed-cg.mdp
+++ b/common-files/alchembed-cg.mdp
@@ -39,3 +39,4 @@ sc-r-power           = 6
 couple-moltype       = PROTEIN
 couple-lambda0       = none
 couple-lambda1       = vdw
+couple-intramol      = yes

--- a/common-files/cox1-at.itp
+++ b/common-files/cox1-at.itp
@@ -1,6 +1,6 @@
 [ moleculetype ]
 ; Name            nrexcl
-Protein     3
+PROTEIN     3
 
 [ atoms ]
 ;   nr       type  resnr residue  atom   cgnr     charge       mass  typeB    chargeB      massB

--- a/common-files/cox1-cg.itp
+++ b/common-files/cox1-cg.itp
@@ -8,7 +8,7 @@
 
 [ moleculetype ]
 ; Name         Exclusions
-Protein         1
+PROTEIN         1
 
 [ atoms ]
     1    P5     1   VAL    BB     1  0.0000 ; C

--- a/common-files/kcsa-cg.itp
+++ b/common-files/kcsa-cg.itp
@@ -8,7 +8,7 @@
 
 [ moleculetype ]
 ; Name         Exclusions
-Protein         1
+PROTEIN         1
 
 [ atoms ]
     1    P5     1   LEU    BB     1  0.0000 ; C

--- a/common-files/nbar-cg.itp
+++ b/common-files/nbar-cg.itp
@@ -8,7 +8,7 @@
 
 [ moleculetype ]
 ; Name         Exclusions
-Protein         1
+PROTEIN         1
 
 [ atoms ]
     1    P5     1   MET    BB     1  0.0000 ; C

--- a/common-files/ompf-cg.itp
+++ b/common-files/ompf-cg.itp
@@ -8,7 +8,7 @@
 
 [ moleculetype ]
 ; Name         Exclusions
-Protein         1
+PROTEIN         1
 
 [ atoms ]
     1    P5     1   GLY    BB     1  0.0000 ; C

--- a/common-files/pla2-at.itp
+++ b/common-files/pla2-at.itp
@@ -1,6 +1,6 @@
 [ moleculetype ]
 ; Name            nrexcl
-Protein  	   		3
+PROTEIN  	   		3
 
 [ atoms ]
 ;   nr       type  resnr residue  atom   cgnr     charge       mass  typeB    chargeB      massB

--- a/common-files/pla2-cg.itp
+++ b/common-files/pla2-cg.itp
@@ -8,7 +8,7 @@
 
 [ moleculetype ]
 ; Name         Exclusions
-Protein         1
+PROTEIN         1
 
 [ atoms ]
     1    P4     1   ALA    BB     1  0.0000 ; C

--- a/try-alchembed.sh
+++ b/try-alchembed.sh
@@ -14,6 +14,10 @@ protein=$1
 # the second is whether it is atomistic (at) or coarse-grained (cg)
 ff=$2
 
+# the third (optional) parameter controls the number of OpenMP threads for the
+# alchembed run. Defaults to 1. More is faster, but too many can break the simulation.
+ntomp=${3:-1}
+
 # create the output directory if it doesn't exist (e.g. nbar/cg/)
 if [ ! -d "$protein" ]; then
 	mkdir $protein
@@ -51,4 +55,4 @@ gmx grompp 	 -f common-files/alchembed-$ff.mdp\
 
 # ..and run on a single core. 
 gmx mdrun -v -deffnm $protein/$ff/$protein-$ff-alchembed\
-	     -ntmpi 1 -ntomp 1
+	     -ntmpi 1 -ntomp $ntomp

--- a/try-alchembed.sh
+++ b/try-alchembed.sh
@@ -1,10 +1,11 @@
 #! /bin/bash
 
-# if necessary, put the required GROMACS version in your $PATH. Check via
-#  > grompp --version
+# Make sure the gromacs binaries `gmx` and `gmx_d` are in your $PATH. Check via
+# $ gmx -h
+# and
+# $ gmx_d -h
 # you may only have one version on your machine, or you may use a modules environment
-
-source /usr/local/gromacs/5.0.4/bin/GMXRC
+# Source the required GMXRC files where necessary.
 
 # this script takes two arguments
 # the first is the name of the protein (from pla2, nbar, cox1, kcsa, ompf)
@@ -23,7 +24,7 @@ if [ ! -d "$protein/$ff" ]; then
 fi
 
 # First, prepare a TPR file for energy minimisation
-grompp 	 -f common-files/em-$ff.mdp\
+gmx grompp 	 -f common-files/em-$ff.mdp\
 		 -c common-files/$protein-$ff.pdb\
 		 -p common-files/$protein-$ff.top\
 		 -n common-files/$protein-$ff.ndx\
@@ -34,13 +35,14 @@ grompp 	 -f common-files/em-$ff.mdp\
 # ..now run using double precision (you may need to compile this as only single precision is compiled by default)
 #  (or just try single precision...)
 # This should only take a few seconds
-mdrun_d  -deffnm $protein/$ff/$protein-$ff-em\
+gmx_d mdrun -v -deffnm $protein/$ff/$protein-$ff-em\
 		 -ntmpi 1
 
 
 # Now, prepare the ALCHEMBED TPR file
-grompp 	 -f common-files/alchembed-$ff.mdp\
+gmx grompp 	 -f common-files/alchembed-$ff.mdp\
 		 -c $protein/$ff/$protein-$ff-em.gro\
+		 -r $protein/$ff/$protein-$ff-em.gro\
 		 -p common-files/$protein-$ff.top\
 		 -n common-files/$protein-$ff.ndx\
 	     -po $protein/$ff/$protein-$ff-alchembed.mdp\
@@ -48,5 +50,5 @@ grompp 	 -f common-files/alchembed-$ff.mdp\
          -maxwarn 2
 
 # ..and run on a single core. 
-mdrun    -deffnm $protein/$ff/$protein-$ff-alchembed\
-	     -ntmpi 1
+gmx mdrun -v -deffnm $protein/$ff/$protein-$ff-alchembed\
+	     -ntmpi 1 -ntomp 1


### PR DESCRIPTION
I have found Alchembed very useful in my work and wanted to share the changes I made to make it work in gromacs2021.5 and gromacs2024.1. 

In my hands and for my systems, it was necessesary to add `couple-intramol=yes` to the mdp file.
Changes to the tutorial files that were necessary for modern gromacs versions:

- Added `gmx` or `gmx_d` before `grompp` and `mdrun`
- added `-r` argument to the alchembed grompp call
- changed a few of the .itp files to say `PROTEIN` instead of `Protein` in `[ moleculetype ]`
- Added `couple-intramol=yes` to alchembed-at.mdp and alchembed-cg.mdp
- added `-ntomp` argument to Alchembed's mdrun call. I got some CUDA errors without it. I modified `try-alchembed.sh` to accept the number of OpenMP threads to use as an optional third command line argument which defaults to 1.
